### PR TITLE
Fix github action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
-          buildArgs: build_branch=master
+          build-args: build_branch=master
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/mmbtools:master,
                 ${{ secrets.DOCKER_HUB_USERNAME }}/mmbtools:latest
       -

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,5 +39,5 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
-          buildArgs: build_branch=next
+          build-args: build_branch=next
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/mmbtools:next


### PR DESCRIPTION
`build-args` is the proper argument for the github action docker-publish